### PR TITLE
Fix deprecation warning about Chained trait.

### DIFF
--- a/lib/HTML/FormFu.pm
+++ b/lib/HTML/FormFu.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::Render',
      'HTML::FormFu::Role::CreateChildren',

--- a/lib/HTML/FormFu/Constraint.pm
+++ b/lib/HTML/FormFu/Constraint.pm
@@ -3,6 +3,7 @@ package HTML::FormFu::Constraint;
 use strict;
 use base 'HTML::FormFu::Processor';
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Processor';
 
 use HTML::FormFu::Exception::Constraint;

--- a/lib/HTML/FormFu/Constraint/Callback.pm
+++ b/lib/HTML/FormFu/Constraint/Callback.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Constraint::Callback;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Constraint';
 
 has callback => ( is => 'rw', traits  => ['Chained'] );

--- a/lib/HTML/FormFu/Constraint/CallbackOnce.pm
+++ b/lib/HTML/FormFu/Constraint/CallbackOnce.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Constraint::CallbackOnce;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Constraint';
 
 has callback => ( is => 'rw', traits => ['Chained'] );

--- a/lib/HTML/FormFu/Constraint/File/MIME.pm
+++ b/lib/HTML/FormFu/Constraint/File/MIME.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Constraint::File::MIME;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Constraint';
 
 use List::MoreUtils qw( any );

--- a/lib/HTML/FormFu/Constraint/File/Size.pm
+++ b/lib/HTML/FormFu/Constraint/File/Size.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Constraint::File::Size;
 use Moose;
+use MooseX::Attribute::Chained;
 use MooseX::Aliases;
 
 extends 'HTML::FormFu::Constraint';

--- a/lib/HTML/FormFu/Constraint/Length.pm
+++ b/lib/HTML/FormFu/Constraint/Length.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Constraint::Length;
 use Moose;
+use MooseX::Attribute::Chained;
 use MooseX::Aliases;
 
 extends 'HTML::FormFu::Constraint';

--- a/lib/HTML/FormFu/Constraint/MinMaxFields.pm
+++ b/lib/HTML/FormFu/Constraint/MinMaxFields.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Constraint::MinMaxFields;
 use Moose;
+use MooseX::Attribute::Chained;
 use MooseX::Aliases;
 extends 'HTML::FormFu::Constraint';
 

--- a/lib/HTML/FormFu/Constraint/Range.pm
+++ b/lib/HTML/FormFu/Constraint/Range.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Constraint::Range;
 use Moose;
+use MooseX::Attribute::Chained;
 use MooseX::Aliases;
 
 extends 'HTML::FormFu::Constraint';

--- a/lib/HTML/FormFu/Constraint/Regex.pm
+++ b/lib/HTML/FormFu/Constraint/Regex.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Constraint::Regex;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Constraint';
 
 use Regexp::Common;

--- a/lib/HTML/FormFu/Constraint/Set.pm
+++ b/lib/HTML/FormFu/Constraint/Set.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Constraint::Set;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Constraint';
 
 use Clone ();

--- a/lib/HTML/FormFu/Deflator.pm
+++ b/lib/HTML/FormFu/Deflator.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Deflator;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::Populate';
 

--- a/lib/HTML/FormFu/Deflator/Callback.pm
+++ b/lib/HTML/FormFu/Deflator/Callback.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Deflator::Callback;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Deflator';
 
 has callback => ( is => 'rw', traits  => ['Chained'] );

--- a/lib/HTML/FormFu/Deflator/CompoundDateTime.pm
+++ b/lib/HTML/FormFu/Deflator/CompoundDateTime.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Deflator::CompoundDateTime;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Deflator';
 
 use HTML::FormFu::Constants qw( $EMPTY_STR );

--- a/lib/HTML/FormFu/Deflator/CompoundSplit.pm
+++ b/lib/HTML/FormFu/Deflator/CompoundSplit.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Deflator::CompoundSplit;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Deflator';
 
 use HTML::FormFu::Constants qw( $EMPTY_STR $SPACE );

--- a/lib/HTML/FormFu/Deflator/FormatNumber.pm
+++ b/lib/HTML/FormFu/Deflator/FormatNumber.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Deflator::FormatNumber;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Deflator';
 
 use Number::Format;

--- a/lib/HTML/FormFu/Deflator/PathClassFile.pm
+++ b/lib/HTML/FormFu/Deflator/PathClassFile.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Deflator::PathClassFile;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Deflator';
 
 has relative => ( is => 'rw', traits => ['Chained'] );

--- a/lib/HTML/FormFu/Deflator/Strftime.pm
+++ b/lib/HTML/FormFu/Deflator/Strftime.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Deflator::Strftime;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Deflator';
 
 has strftime => ( is => 'rw', traits => ['Chained'] );

--- a/lib/HTML/FormFu/Element.pm
+++ b/lib/HTML/FormFu/Element.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Element;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::Render',
      'HTML::FormFu::Role::FormAndElementMethods',

--- a/lib/HTML/FormFu/Element/Block.pm
+++ b/lib/HTML/FormFu/Element/Block.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Element::Block;
 use Moose;
+use MooseX::Attribute::Chained;
 
 extends 'HTML::FormFu::Element';
 

--- a/lib/HTML/FormFu/Element/Checkboxgroup.pm
+++ b/lib/HTML/FormFu/Element/Checkboxgroup.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Element::Checkboxgroup;
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Element';
 
 with 'HTML::FormFu::Role::Element::Group';

--- a/lib/HTML/FormFu/Element/ComboBox.pm
+++ b/lib/HTML/FormFu/Element/ComboBox.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Element::ComboBox;
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Element::Multi';
 
 with 'HTML::FormFu::Role::Element::ProcessOptionsFromModel';

--- a/lib/HTML/FormFu/Element/ContentButton.pm
+++ b/lib/HTML/FormFu/Element/ContentButton.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Element::ContentButton;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends "HTML::FormFu::Element";
 with 'HTML::FormFu::Role::Element::Field';
 with "HTML::FormFu::Role::Element::SingleValueField";

--- a/lib/HTML/FormFu/Element/Date.pm
+++ b/lib/HTML/FormFu/Element/Date.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Element::Date;
 use Moose;
+use MooseX::Attribute::Chained;
 
 extends 'HTML::FormFu::Element::Multi';
 

--- a/lib/HTML/FormFu/Element/DateTime.pm
+++ b/lib/HTML/FormFu/Element/DateTime.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Element::DateTime;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Element::Date';
 
 use Moose::Util qw( apply_all_roles );

--- a/lib/HTML/FormFu/Element/Label.pm
+++ b/lib/HTML/FormFu/Element/Label.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Element::Label;
 use Moose;
+use MooseX::Attribute::Chained;
 
 extends "HTML::FormFu::Element";
 

--- a/lib/HTML/FormFu/Element/Password.pm
+++ b/lib/HTML/FormFu/Element/Password.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Element::Password;
 use Moose;
+use MooseX::Attribute::Chained;
 
 extends 'HTML::FormFu::Element';
 

--- a/lib/HTML/FormFu/Element/Radiogroup.pm
+++ b/lib/HTML/FormFu/Element/Radiogroup.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Element::Radiogroup;
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Element::Checkboxgroup';
 
 use HTML::FormFu::Constants qw( $EMPTY_STR );

--- a/lib/HTML/FormFu/Element/Repeatable.pm
+++ b/lib/HTML/FormFu/Element/Repeatable.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Element::Repeatable;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Element::Block';
 
 use HTML::FormFu::Util qw( DEBUG_PROCESS debug );

--- a/lib/HTML/FormFu/Element/SimpleTable.pm
+++ b/lib/HTML/FormFu/Element/SimpleTable.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Element::SimpleTable;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Element::Block';
 
 use HTML::FormFu::Util qw( append_xml_attribute );

--- a/lib/HTML/FormFu/Element/reCAPTCHA.pm
+++ b/lib/HTML/FormFu/Element/reCAPTCHA.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Element::reCAPTCHA;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Element::Multi';
 
 use HTML::FormFu::Util qw( process_attrs _merge_hashes );

--- a/lib/HTML/FormFu/Exception/Input.pm
+++ b/lib/HTML/FormFu/Exception/Input.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Exception::Input;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Exception';
 
 use HTML::FormFu::Util qw( literal );

--- a/lib/HTML/FormFu/Filter.pm
+++ b/lib/HTML/FormFu/Filter.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Filter;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::NestedHashUtils',
      'HTML::FormFu::Role::HasParent',

--- a/lib/HTML/FormFu/Filter/Callback.pm
+++ b/lib/HTML/FormFu/Filter/Callback.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Filter::Callback;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Filter';
 
 has callback => ( is => 'rw', traits => ['Chained'] );

--- a/lib/HTML/FormFu/Filter/CompoundJoin.pm
+++ b/lib/HTML/FormFu/Filter/CompoundJoin.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Filter::CompoundJoin;
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Filter';
 
 with 'HTML::FormFu::Role::Filter::Compound';

--- a/lib/HTML/FormFu/Filter/CompoundSprintf.pm
+++ b/lib/HTML/FormFu/Filter/CompoundSprintf.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Filter::CompoundSprintf;
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Filter';
 
 with 'HTML::FormFu::Role::Filter::Compound';

--- a/lib/HTML/FormFu/Filter/CopyValue.pm
+++ b/lib/HTML/FormFu/Filter/CopyValue.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Filter::CopyValue;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Filter';
 
 has field => ( is => 'rw', traits => ['Chained'] );

--- a/lib/HTML/FormFu/Filter/Default.pm
+++ b/lib/HTML/FormFu/Filter/Default.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Filter::Default;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Filter';
 
 has value => ( is => 'rw', traits => ['Chained'] );

--- a/lib/HTML/FormFu/Filter/Encode.pm
+++ b/lib/HTML/FormFu/Filter/Encode.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Filter::Encode;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Filter';
 
 use Encode qw(encode decode FB_CROAK);

--- a/lib/HTML/FormFu/Filter/HTMLScrubber.pm
+++ b/lib/HTML/FormFu/Filter/HTMLScrubber.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Filter::HTMLScrubber;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Filter';
 
 use Clone ();

--- a/lib/HTML/FormFu/Filter/Regex.pm
+++ b/lib/HTML/FormFu/Filter/Regex.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Filter::Regex;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Filter';
 
 use HTML::FormFu::Constants qw( $EMPTY_STR );

--- a/lib/HTML/FormFu/Filter/Split.pm
+++ b/lib/HTML/FormFu/Filter/Split.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Filter::Split;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Filter';
 
 has regex => ( is => 'rw', traits => ['Chained'] );

--- a/lib/HTML/FormFu/Inflator/Callback.pm
+++ b/lib/HTML/FormFu/Inflator/Callback.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Inflator::Callback;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Inflator';
 
 has callback => ( is => 'rw', traits  => ['Chained'] );

--- a/lib/HTML/FormFu/Inflator/CompoundDateTime.pm
+++ b/lib/HTML/FormFu/Inflator/CompoundDateTime.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Inflator::CompoundDateTime;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Inflator';
 
 use HTML::FormFu::Constants qw( $EMPTY_STR );

--- a/lib/HTML/FormFu/Inflator/DateTime.pm
+++ b/lib/HTML/FormFu/Inflator/DateTime.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Inflator::DateTime;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Inflator';
 
 use HTML::FormFu::Constants qw( $EMPTY_STR );

--- a/lib/HTML/FormFu/Model.pm
+++ b/lib/HTML/FormFu/Model.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Model;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::HasParent';
 

--- a/lib/HTML/FormFu/Model/HashRef.pm
+++ b/lib/HTML/FormFu/Model/HashRef.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Model::HashRef;
 use Moose;
+use MooseX::Attribute::Chained;
 
 extends 'HTML::FormFu::Model';
 

--- a/lib/HTML/FormFu/MultiForm.pm
+++ b/lib/HTML/FormFu/MultiForm.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::MultiForm;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::FormAndElementMethods' => { -excludes => 'model_config' },
      'HTML::FormFu::Role::NestedHashUtils',

--- a/lib/HTML/FormFu/OutputProcessor.pm
+++ b/lib/HTML/FormFu/OutputProcessor.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::OutputProcessor;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::HasParent',
      'HTML::FormFu::Role::Populate';

--- a/lib/HTML/FormFu/OutputProcessor/Indent.pm
+++ b/lib/HTML/FormFu/OutputProcessor/Indent.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::OutputProcessor::Indent;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::OutputProcessor';
 
 use HTML::FormFu::Constants qw( $EMPTY_STR $SPACE );

--- a/lib/HTML/FormFu/OutputProcessor/StripWhitespace.pm
+++ b/lib/HTML/FormFu/OutputProcessor/StripWhitespace.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::OutputProcessor::StripWhitespace;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::OutputProcessor';
 
 use HTML::FormFu::Constants qw( $EMPTY_STR );
@@ -121,6 +122,7 @@ __PACKAGE__->meta->make_immutable;
 
 package HTML::FormFu::OutputProcessor::StripWhitespace::_iter;
 use Moose;
+use MooseX::Attribute::Chained;
 
 sub new {
     my ( $class, @tags ) = @_;

--- a/lib/HTML/FormFu/Plugin.pm
+++ b/lib/HTML/FormFu/Plugin.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Plugin;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::HasParent',
      'HTML::FormFu::Role::Populate';

--- a/lib/HTML/FormFu/Processor.pm
+++ b/lib/HTML/FormFu/Processor.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Processor;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::NestedHashUtils',
      'HTML::FormFu::Role::HasParent',

--- a/lib/HTML/FormFu/QueryType/Catalyst.pm
+++ b/lib/HTML/FormFu/QueryType/Catalyst.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::QueryType::Catalyst;
 use Moose;
+use MooseX::Attribute::Chained;
 
 extends 'HTML::FormFu::Upload';
 

--- a/lib/HTML/FormFu/Transformer/Callback.pm
+++ b/lib/HTML/FormFu/Transformer/Callback.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Transformer::Callback;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Transformer';
 
 has callback => ( is => 'rw', traits => ['Chained'] );

--- a/lib/HTML/FormFu/Upload.pm
+++ b/lib/HTML/FormFu/Upload.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::Upload;
 use Moose;
+use MooseX::Attribute::Chained;
 
 with 'HTML::FormFu::Role::Populate';
 

--- a/lib/HTML/FormFu/UploadParam.pm
+++ b/lib/HTML/FormFu/UploadParam.pm
@@ -1,5 +1,6 @@
 package HTML::FormFu::UploadParam;
 use Moose;
+use MooseX::Attribute::Chained;
 
 use Carp qw( croak );
 

--- a/lib/HTML/FormFu/Validator/Callback.pm
+++ b/lib/HTML/FormFu/Validator/Callback.pm
@@ -1,6 +1,7 @@
 package HTML::FormFu::Validator::Callback;
 
 use Moose;
+use MooseX::Attribute::Chained;
 extends 'HTML::FormFu::Validator';
 
 has callback => ( is => 'rw', traits => ['Chained'] );


### PR DESCRIPTION
The way HTML::FormFu currently does Chained accessors has been deprecated and throws numerous warnings:

"Implicit use of the Chained trait is deprecated. Please load MooseX::Attribute::Chained explicitly"

This pull request should fix the problem.
