### PR TITLE
uninitialized warnings in logs

### DIFF
--- a/lib/HTML/FormFu/Constraint.pm
+++ b/lib/HTML/FormFu/Constraint.pm
@@ -105,7 +105,7 @@ sub _find_field_value {
         croak 'did not find ourself - how can this happen?'
             if !defined $index;
         
-        if ( reftype($value) eq 'ARRAY' ) {
+        if ( ( reftype($value) || '' ) eq 'ARRAY' ) {
             $value = $value->[$index];
         }
         elsif ( $index == 0 ) {


### PR DESCRIPTION
Our logs are full of: Use of uninitialized value in string eq at /usr/local/share/perl/5.10.1/HTML/FormFu/Constraint.pm line 108. 'reftype' can return undef, which isn't handled by the "eq 'ARRAY'".
