### PR TITLE
Add a missing semicolon to an example.

### DIFF
--- a/lib/HTML/FormFu/Manual/Cookbook.pod
+++ b/lib/HTML/FormFu/Manual/Cookbook.pod
@@ -278,7 +278,7 @@ only if the value of another field contains a pattern
         my $params = shift;
         return 1 if $params->{other_field} =~ m/\A ice_cream \z/xms;
         return 0;
-    }
+    };
 
     $field->{constraints} = {
         type    => 'Required',


### PR DESCRIPTION
Add a missing semicolon to an example.
