### PR TITLE
fix ForceListValue whatis entry

### DIFF
--- a/lib/HTML/FormFu/Filter/ForceListValue.pm
+++ b/lib/HTML/FormFu/Filter/ForceListValue.pm
@@ -17,7 +17,7 @@ sub process {
 
 =head1 NAME
 
-HTML::FormFu::Filter::ForceListValue
+HTML::FormFu::Filter::ForceListValue - convert a single value into a 1-item-list
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
the one-line description after the dash in the NAME section is important e.g. for pod2man and the whatis database created from installed man pages
