### PR TITLE
fix HTML::FormFu::Validator example code.

### DIFF
--- a/lib/HTML/FormFu/Validator.pm
+++ b/lib/HTML/FormFu/Validator.pm
@@ -107,9 +107,8 @@ And the class would be something like this:
 
     package HTML::FormFu::Validator::MyApp::SomeValidator;
     use strict;
-# VERSION
 
-use Moose;
+    use Moose;
     extends 'HTML::FormFu::Validator';
 
     sub validate_value {


### PR DESCRIPTION
Fix indentation of example code in best practices and remove `#VERSION` string that was accidentally added during bulk change in SHA:889442105fb5eeb5ce23ac409ffd38321e1009dd .