### PR TITLE
Separate email & MX checks, require internet for MX

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -69,6 +69,7 @@ Regexp::Assemble = 0
 Test::More = 0.92
 Test::Exception = 0
 Test::Memory::Cycle = 0         ; for the xt/circular_reference.t
+Test::RequiresInternet = 0
 
 ;; --
 ;; -- Sets of additional tests we want to do as part of release

--- a/t/constraints/email-mx.t
+++ b/t/constraints/email-mx.t
@@ -1,0 +1,58 @@
+use strict;
+use warnings;
+
+use Test::RequiresInternet 'cpan.org' => 80;
+use Test::More tests => 3;
+
+use HTML::FormFu;
+
+{
+
+my $form = HTML::FormFu->new;
+
+$form->element('Text')->name('foo')->constraint('Email')->options('mxcheck');
+
+# Valid - Scalar
+{
+
+    $form->process( { foo => 'cfranks@cpan.org' } );
+
+    ok( $form->valid('foo'), 'foo valid - mxcheck scalar' );
+
+}
+
+}
+
+{
+
+my $form = HTML::FormFu->new;
+
+$form->element('Text')->name('foo')->constraint('Email')->options(['mxcheck']);
+
+# Valid - Array
+{
+
+    $form->process( { foo => 'djzort@cpan.org' } );
+
+    ok( $form->valid('foo'), 'foo valid - mxcheck array' );
+
+}
+
+}
+
+{
+
+my $form = HTML::FormFu->new;
+
+$form->element('Text')->name('foo')->constraint('Email')->options({'mxcheck' => 1 });
+
+# Valid - Hash
+{
+
+    $form->process( { foo => 'djzort@cpan.org', options => { 'mxcheck' => 1 } } );
+
+    ok( $form->valid('foo'), 'foo valid - mxcheck hash' );
+
+}
+
+}

--- a/t/constraints/email.t
+++ b/t/constraints/email.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 4;
 
 use HTML::FormFu;
 
@@ -31,57 +31,6 @@ $form->element('Text')->name('foo')->constraint('Email');
     $form->process( { foo => 'rjbs@[1.2.3.4]' } );
 
     ok( $form->valid('foo'), 'foo valid - ip ok by default' );
-
-}
-
-}
-
-{
-
-my $form = HTML::FormFu->new;
-
-$form->element('Text')->name('foo')->constraint('Email')->options('mxcheck');
-
-# Valid - Scalar
-{
-
-    $form->process( { foo => 'cfranks@cpan.org' } );
-
-    ok( $form->valid('foo'), 'foo valid - mxcheck scalar' );
-
-}
-
-}
-
-{
-
-my $form = HTML::FormFu->new;
-
-$form->element('Text')->name('foo')->constraint('Email')->options(['mxcheck']);
-
-# Valid - Array
-{
-
-    $form->process( { foo => 'djzort@cpan.org' } );
-
-    ok( $form->valid('foo'), 'foo valid - mxcheck array' );
-
-}
-
-}
-
-{
-
-my $form = HTML::FormFu->new;
-
-$form->element('Text')->name('foo')->constraint('Email')->options({'mxcheck' => 1 });
-
-# Valid - Hash
-{
-
-    $form->process( { foo => 'djzort@cpan.org', options => { 'mxcheck' => 1 } } );
-
-    ok( $form->valid('foo'), 'foo valid - mxcheck hash' );
 
 }
 


### PR DESCRIPTION
There were two test failures reported on CPAN Testers, where
email checks with MX were failing. I was able to reproduce it
by disconnecting.

https://www.cpantesters.org/cpan/report/001aa88c-18eb-11e7-9f47-557d87ebc929
https://www.cpantesters.org/cpan/report/198aed3a-17de-11e7-a4a0-8eacd02b4708

This patch separates these checks into two test files.
Also adds "RequiresInternet" for MX checks.