### PR TITLE
Remove links to defunct lacunaexpanse

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,8 @@
     - remove bundled/renamed MooseX::Attribute::Chained and depend on the
       fixed version
 
+    - Remove out-of-date reference to lacunaexpanse.
+
 2.05      2016-10-07 15:34:52+01:00 Europe/London
 
     - Release machinery - dzil transition to @Starter and simplification

--- a/README.pod
+++ b/README.pod
@@ -2046,10 +2046,6 @@ Nigel Metheringham
 Based on the original source code of L<HTML::Widget>, by Sebastian Riedel,
 C<sri@oook.de>.
 
-=head1 PERL GAME
-
-Play the MMO written in perl: L<http://www.lacunaexpanse.com>!
-
 =head1 AUTHOR
 
 Carl Franks <cpan@fireartist.com>

--- a/lib/HTML/FormFu.pm
+++ b/lib/HTML/FormFu.pm
@@ -3253,8 +3253,4 @@ Nigel Metheringham
 Based on the original source code of L<HTML::Widget>, by Sebastian Riedel,
 C<sri@oook.de>.
 
-=head1 PERL GAME
-
-Play the MMO written in perl: L<http://www.lacunaexpanse.com>!
-
 =cut


### PR DESCRIPTION
lacunaexpanse.com is dead, long live lacunaexpanse.