### PR TITLE
WIP: Issue/24 error attributes

### DIFF
--- a/lib/HTML/FormFu/Role/Element/Field.pm
+++ b/lib/HTML/FormFu/Role/Element/Field.pm
@@ -1070,15 +1070,18 @@ sub _string_errors {
             ;
     }
 
+    # work around leaky abstraction to fix #24
+    my $default_error_attributes = defined $self->{error_attributes}
+                                 ? $self->{error_attributes}
+                                 : $render->{error_attributes};
     my @error_html;
     for my $error ( @{ $render->{errors} } ) {
+        my $error_attributes = %{ $error->{attributes}}
+                             ? $error->{attributes}
+                             : $default_error_attributes;
         push @error_html, sprintf qq{<%s%s>%s</%s>},
             $render->{error_tag},
-            process_attrs( $error->{attributes} ),
-# works for Text
-#            process_attrs( $render->{error_attributes} ),
-# works for Select
-#            process_attrs( $self->{error_attributes} ),
+            process_attrs( $error_attributes ),
             $error->{message},
             $render->{error_tag},
             ;

--- a/lib/HTML/FormFu/Role/Element/Field.pm
+++ b/lib/HTML/FormFu/Role/Element/Field.pm
@@ -1075,6 +1075,10 @@ sub _string_errors {
         push @error_html, sprintf qq{<%s%s>%s</%s>},
             $render->{error_tag},
             process_attrs( $error->{attributes} ),
+# works for Text
+#            process_attrs( $render->{error_attributes} ),
+# works for Select
+#            process_attrs( $self->{error_attributes} ),
             $error->{message},
             $render->{error_tag},
             ;

--- a/t-aggregate/elements/error_attributes_failing_test.select-with-attrs.yml
+++ b/t-aggregate/elements/error_attributes_failing_test.select-with-attrs.yml
@@ -1,0 +1,12 @@
+---
+elements:
+    - type: Select
+      name: foo
+      error_attributes:
+          class: 'class-error_attributes'
+      options:
+        - [1, One]
+        - [2, Two]
+      constraints:
+        - type: AutoSet
+          message: 'test'

--- a/t-aggregate/elements/error_attributes_failing_test.select.yml
+++ b/t-aggregate/elements/error_attributes_failing_test.select.yml
@@ -1,0 +1,10 @@
+---
+elements:
+    - type: Select
+      name: foo
+      options:
+        - [1, One]
+        - [2, Two]
+      constraints:
+        - type: AutoSet
+          message: 'test'

--- a/t-aggregate/elements/error_attributes_failing_test.t
+++ b/t-aggregate/elements/error_attributes_failing_test.t
@@ -1,0 +1,123 @@
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+use HTML::FormFu;
+
+{
+    my $form = HTML::FormFu->new(
+        { tt_args => { INCLUDE_PATH => 'share/templates/tt/xhtml' } } );
+
+    $form->load_config_file('t-aggregate/elements/error_attributes_failing_test.text-with-attrs.yml');
+
+    $form->process({
+        foo => 3333,
+    });
+
+    is( "$form", <<EOF );
+<form action="" method="post">
+<div>
+<span class="class-error_attributes">test</span>
+<label>Foo</label>
+<input name="foo" type="text" value="3333" />
+</div>
+</form>
+EOF
+}
+
+{
+    my $form = HTML::FormFu->new(
+        { tt_args => { INCLUDE_PATH => 'share/templates/tt/xhtml' } } );
+
+    $form->default_args({
+        elements => {
+            Field => {
+                error_attributes => {
+                    class => 'class-error_attributes',
+                },
+                attributes => {
+                    class => 'class-attributes', # used in the error_tag!
+                },
+            },
+            layout => [qw/label errors field comment javascript/],
+        },
+    });
+
+
+    $form->load_config_file('t-aggregate/elements/error_attributes_failing_test.text.yml');
+
+    $form->process({
+        foo => 3333,
+    });
+
+    is( "$form", <<EOF );
+<form action="" method="post">
+<div>
+<span class="class-error_attributes">test</span>
+<label>Foo</label>
+<input name="foo" type="text" value="3333" class="class-attributes" />
+</div>
+</form>
+EOF
+}
+
+{
+    my $form = HTML::FormFu->new(
+        { tt_args => { INCLUDE_PATH => 'share/templates/tt/xhtml' } } );
+
+    $form->load_config_file('t-aggregate/elements/error_attributes_failing_test.select-with-attrs.yml');
+
+    $form->process({
+        foo => 3333,
+    });
+
+    is( "$form", <<EOF );
+<form action="" method="post">
+<div>
+<span class="class-error_attributes">test</span>
+<select name="foo">
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+</div>
+</form>
+EOF
+}
+
+{
+    my $form = HTML::FormFu->new(
+        { tt_args => { INCLUDE_PATH => 'share/templates/tt/xhtml' } } );
+
+    $form->default_args({
+        elements => {
+            Field => {
+                error_attributes => {
+                    class => 'class-error_attributes',
+                },
+                attributes => {
+                    class => 'class-attributes',
+                },
+            },
+            layout => [qw/label errors field comment javascript/],
+        },
+    });
+
+    $form->load_config_file('t-aggregate/elements/error_attributes_failing_test.select.yml');
+
+    $form->process({
+        foo => 3333,
+    });
+
+    is( "$form", <<EOF );
+<form action="" method="post">
+<div>
+<span class="class-error_attributes">test</span>
+<select name="foo" class="class-attributes">
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+</div>
+</form>
+EOF
+}

--- a/t-aggregate/elements/error_attributes_failing_test.text-with-attrs.yml
+++ b/t-aggregate/elements/error_attributes_failing_test.text-with-attrs.yml
@@ -1,0 +1,11 @@
+---
+elements:
+    - type: Text
+      name: foo
+      label: Foo
+      error_attributes:
+          class: 'class-error_attributes'
+      constraints:
+        - type: MaxLength
+          max: 3
+          message: 'test'

--- a/t-aggregate/elements/error_attributes_failing_test.text.yml
+++ b/t-aggregate/elements/error_attributes_failing_test.text.yml
@@ -1,0 +1,11 @@
+---
+elements:
+    - type: Text
+      name: foo
+      label: Foo
+      error_attributes:
+          class: 'class-error_attributes'
+      constraints:
+        - type: MaxLength
+          max: 3
+          message: 'test'


### PR DESCRIPTION
I pulled in the test files (`t-aggregate/*` ) from @sadrak 's branch and added a super hacky workaround.

Need to pull together the idea of `error_attributes` from `$self` and `$render` against the  `$error->{attribute}` from `$render->{errors}`.

* `$self->{error_attributes}` :: works for Text
* `$render->{error_attributes}` :: works for Select
* `$error->{attribute}` :: works with auto_error_class 


Also, where should these new test files go?  We don't need them on a top-level directory.