### PR TITLE
Add #ABSTRACT headers for Pod::Weaver @Default/Name plugin

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -4,7 +4,7 @@
 
 =head1 NAME
 
-HTML::FormFu
+HTML::FormFu - HTML Form Creation, Rendering and Validation Framework
 
 =head1 VERSION
 
@@ -120,10 +120,6 @@ will mainly be shown in L<YAML> config syntax.
 This documentation follows the convention that method arguments surrounded
 by square brackets C<[]> are I<optional>, and all other arguments are
 required.
-
-=head1 NAME
-
-HTML::FormFu - HTML Form Creation, Rendering and Validation Framework
 
 =head1 BUILDING A FORM
 

--- a/bin/html_formfu_deploy.pl
+++ b/bin/html_formfu_deploy.pl
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 # PODNAME: html_formfu_deploy.pl
+# ABSTRACT: deploy local copy of HTML::FormFu template files
 
 use HTML::FormFu::Deploy;
 
@@ -21,10 +22,6 @@ if ( @ARGV != 1 ) {
 HTML::FormFu::Deploy::deploy( $ARGV[0] );
 
 __END__
-
-=head1 NAME
-
-html_formfu_deploy.pl - deploy local copy of HTML::FormFu template files
 
 =head1 SYNOPSIS
 

--- a/bin/html_formfu_dumpconf.pl
+++ b/bin/html_formfu_dumpconf.pl
@@ -7,6 +7,7 @@ use Data::Dumper ();
 use Regexp::Assemble;
 
 # PODNAME: html_formfu_dumpconf.pl
+# ABSTRACT: dump configuration files
 
 if ( @ARGV == 1 && $ARGV[0] =~ m/\A --? h(?:elp)? \z/ix) {
     help();
@@ -80,10 +81,6 @@ HELP
 }
 
 __END__
-
-=head1 NAME
-
-html_formfu_dumpconf.pl - dump configuration files
 
 =head1 SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -78,7 +78,7 @@ Test::RequiresInternet = 0
 [MetaTests]
 ;; [PodCoverageTests]           ; Currently we comprehensively fail these
 [PkgVersion]
-; [PodVersion] ; PodWeaver does this and mode
+; [PodVersion] ; PodWeaver does this and more
 [PodWeaver]
 [Test::Kwalitee]
 [Test::EOL]

--- a/lib/HTML/FormFu.pm
+++ b/lib/HTML/FormFu.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu;
+# ABSTRACT: HTML Form Creation, Rendering and Validation Framework
 
 
 use Moose;
@@ -1214,10 +1215,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu - HTML Form Creation, Rendering and Validation Framework
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Attribute.pm
+++ b/lib/HTML/FormFu/Attribute.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Attribute;
+# ABSTRACT: accessor class
 
 use warnings;
 
@@ -555,10 +556,6 @@ sub mk_attr_bool_accessors {
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Attribute - accessor class
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint.pm
+++ b/lib/HTML/FormFu/Constraint.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint;
+# ABSTRACT: Constrain User Input
 
 
 use Moose;
@@ -344,10 +345,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint - Constrain User Input
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/ASCII.pm
+++ b/lib/HTML/FormFu/Constraint/ASCII.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::ASCII;
+# ABSTRACT: ASCII Characters Constraint
 
 
 use Moose;
@@ -14,10 +15,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::ASCII - ASCII Characters Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/AllOrNone.pm
+++ b/lib/HTML/FormFu/Constraint/AllOrNone.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::AllOrNone;
+# ABSTRACT: Multi-field All or None Constraint
 
 
 use Moose;
@@ -67,10 +68,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::AllOrNone - Multi-field All or None Constraint
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/AutoSet.pm
+++ b/lib/HTML/FormFu/Constraint/AutoSet.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::AutoSet;
+# ABSTRACT: Set Constraint for Selects / Radiogroups / Checkboxgroups
 
 
 use Moose;
@@ -34,10 +35,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::AutoSet - Set Constraint for Selects / Radiogroups / Checkboxgroups
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Bool.pm
+++ b/lib/HTML/FormFu/Constraint/Bool.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Bool;
+# ABSTRACT: Boolean Constraint
 
 
 use Moose;
@@ -14,10 +15,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Bool - Boolean Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Callback.pm
+++ b/lib/HTML/FormFu/Constraint/Callback.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Callback;
+# ABSTRACT: Code Callback Constraint
 
 
 use Moose;
@@ -26,10 +27,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Callback - Code Callback Constraint
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/CallbackOnce.pm
+++ b/lib/HTML/FormFu/Constraint/CallbackOnce.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::CallbackOnce;
+# ABSTRACT: Code Callback Constraint
 
 
 use Moose;
@@ -34,10 +35,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::CallbackOnce - Code Callback Constraint
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/DateTime.pm
+++ b/lib/HTML/FormFu/Constraint/DateTime.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::DateTime;
+# ABSTRACT: DateTime constraint
 
 
 use Moose;
@@ -46,10 +47,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::DateTime - DateTime constraint
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/DependOn.pm
+++ b/lib/HTML/FormFu/Constraint/DependOn.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::DependOn;
+# ABSTRACT: Multi-field Dependency Constraint
 
 
 use Moose;
@@ -82,10 +83,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::DependOn - Multi-field Dependency Constraint
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/Email.pm
+++ b/lib/HTML/FormFu/Constraint/Email.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Email;
+# ABSTRACT: Email Address Constraint
 
 
 use Moose;
@@ -55,10 +56,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Email - Email Address Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Equal.pm
+++ b/lib/HTML/FormFu/Constraint/Equal.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Equal;
+# ABSTRACT: Multi-field Equality Constraint
 
 
 use Moose;
@@ -116,10 +117,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Equal - Multi-field Equality Constraint
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/File.pm
+++ b/lib/HTML/FormFu/Constraint/File.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::File;
+# ABSTRACT: File Upload Constraint
 
 
 use Moose;
@@ -20,10 +21,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::File - File Upload Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/File/MIME.pm
+++ b/lib/HTML/FormFu/Constraint/File/MIME.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::File::MIME;
+# ABSTRACT: MIME Type Constraint
 
 
 use Moose;
@@ -43,10 +44,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::File::MIME - MIME Type Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/File/MaxSize.pm
+++ b/lib/HTML/FormFu/Constraint/File/MaxSize.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::File::MaxSize;
+# ABSTRACT: Maximum File Size Constraint
 
 
 use Moose;
@@ -16,10 +17,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::File::MaxSize - Maximum File Size Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/File/MinSize.pm
+++ b/lib/HTML/FormFu/Constraint/File/MinSize.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::File::MinSize;
+# ABSTRACT: Minimum File Size Constraint
 
 
 use Moose;
@@ -16,10 +17,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::File::MinSize - Minimum File Size Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/File/Size.pm
+++ b/lib/HTML/FormFu/Constraint/File/Size.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::File::Size;
+# ABSTRACT: File Size Constraint
 
 
 use Moose;
@@ -98,10 +99,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::File::Size - File Size Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Integer.pm
+++ b/lib/HTML/FormFu/Constraint/Integer.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Integer;
+# ABSTRACT: Unsigned Integer Constraint
 
 
 use Moose;
@@ -12,10 +13,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Integer - Unsigned Integer Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Length.pm
+++ b/lib/HTML/FormFu/Constraint/Length.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Length;
+# ABSTRACT: Min/Max Length String Constraint
 
 
 use Moose;
@@ -47,10 +48,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Length - Min/Max Length String Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/MaxLength.pm
+++ b/lib/HTML/FormFu/Constraint/MaxLength.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::MaxLength;
+# ABSTRACT: Maximum Length String Constraint
 
 
 use Moose;
@@ -16,10 +17,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::MaxLength - Maximum Length String Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/MaxRange.pm
+++ b/lib/HTML/FormFu/Constraint/MaxRange.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::MaxRange;
+# ABSTRACT: Maximum Value Constraint
 
 
 use Moose;
@@ -16,10 +17,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::MaxRange - Maximum Value Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/MinLength.pm
+++ b/lib/HTML/FormFu/Constraint/MinLength.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::MinLength;
+# ABSTRACT: Minimum Length String Constraint
 
 
 use Moose;
@@ -16,10 +17,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::MinLength - Minimum Length String Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/MinMaxFields.pm
+++ b/lib/HTML/FormFu/Constraint/MinMaxFields.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::MinMaxFields;
+# ABSTRACT: Min/Max Multi-field Constraint
 
 
 use Moose;
@@ -102,10 +103,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::MinMaxFields - Min/Max Multi-field Constraint
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/MinRange.pm
+++ b/lib/HTML/FormFu/Constraint/MinRange.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::MinRange;
+# ABSTRACT: Minimum Value Constraint
 
 
 use Moose;
@@ -16,10 +17,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::MinRange - Minimum Value Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Number.pm
+++ b/lib/HTML/FormFu/Constraint/Number.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Number;
+# ABSTRACT: Numerical Constraint
 
 
 use Moose;
@@ -22,10 +23,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Number - Numerical Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Printable.pm
+++ b/lib/HTML/FormFu/Constraint/Printable.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Printable;
+# ABSTRACT: Printable Characters Constraint
 
 
 use Moose;
@@ -14,10 +15,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Printable - Printable Characters Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Range.pm
+++ b/lib/HTML/FormFu/Constraint/Range.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Range;
+# ABSTRACT: Numerical Range Constraint
 
 
 use Moose;
@@ -51,10 +52,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Range - Numerical Range Constraint
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/Regex.pm
+++ b/lib/HTML/FormFu/Constraint/Regex.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Regex;
+# ABSTRACT: Regex Constraint
 
 
 use Moose;
@@ -53,10 +54,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Regex - Regex Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Repeatable/Any.pm
+++ b/lib/HTML/FormFu/Constraint/Repeatable/Any.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Repeatable::Any;
+# ABSTRACT: Ensure at least 1 of a repeated field is filled-in
 
 
 use Moose;
@@ -114,10 +115,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Repeatable::Any - Ensure at least 1 of a repeated field is filled-in
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/Required.pm
+++ b/lib/HTML/FormFu/Constraint/Required.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Required;
+# ABSTRACT: Required Field Constraint
 
 
 use Moose;
@@ -16,10 +17,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Required - Required Field Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Set.pm
+++ b/lib/HTML/FormFu/Constraint/Set.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Set;
+# ABSTRACT: Set of Values Constraint
 
 
 use Moose;
@@ -39,10 +40,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Set - Set of Values Constraint
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Constraint/SingleValue.pm
+++ b/lib/HTML/FormFu/Constraint/SingleValue.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::SingleValue;
+# ABSTRACT: Single Value Constraint
 
 
 use Moose;
@@ -20,10 +21,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::SingleValue - Single Value Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Constraint/Word.pm
+++ b/lib/HTML/FormFu/Constraint/Word.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Constraint::Word;
+# ABSTRACT: Single Word Constraint
 
 
 use Moose;
@@ -14,10 +15,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Constraint::Word - Single Word Constraint
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Deflator.pm
+++ b/lib/HTML/FormFu/Deflator.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Deflator;
+# ABSTRACT: Deflator Base Class
 
 
 use Moose;
@@ -40,10 +41,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Deflator - Deflator Base Class
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Deflator/Callback.pm
+++ b/lib/HTML/FormFu/Deflator/Callback.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Deflator::Callback;
+# ABSTRACT: Callback deflator
 
 
 use Moose;
@@ -24,10 +25,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Deflator::Callback - Callback deflator
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Deflator/CompoundDateTime.pm
+++ b/lib/HTML/FormFu/Deflator/CompoundDateTime.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Deflator::CompoundDateTime;
+# ABSTRACT: CompoundDateTime deflator
 
 
 use Moose;
@@ -57,10 +58,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Deflator::CompoundDateTime - CompoundDateTime deflator
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Deflator/CompoundSplit.pm
+++ b/lib/HTML/FormFu/Deflator/CompoundSplit.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Deflator::CompoundSplit;
+# ABSTRACT: CompoundSplit deflator
 
 
 use Moose;
@@ -76,10 +77,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Deflator::CompoundSplit - CompoundSplit deflator
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Deflator/FormatNumber.pm
+++ b/lib/HTML/FormFu/Deflator/FormatNumber.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Deflator::FormatNumber;
+# ABSTRACT: Format a number for a locale
 
 
 use Moose;
@@ -55,10 +56,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Deflator::FormatNumber - Format a number for a locale
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Deflator/PathClassFile.pm
+++ b/lib/HTML/FormFu/Deflator/PathClassFile.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Deflator::PathClassFile;
+# ABSTRACT: Deflator for Path::Class::File objects
 
 
 use Moose;
@@ -39,10 +40,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Deflator::PathClassFile - Deflator for Path::Class::File objects
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Deflator/Strftime.pm
+++ b/lib/HTML/FormFu/Deflator/Strftime.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Deflator::Strftime;
+# ABSTRACT: Strftime deflator
 
 
 use Moose;
@@ -33,10 +34,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Deflator::Strftime - Strftime deflator
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element.pm
+++ b/lib/HTML/FormFu/Element.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element;
+# ABSTRACT: Element Base Class
 
 
 use Moose;
@@ -277,10 +278,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element - Element Base Class
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Blank.pm
+++ b/lib/HTML/FormFu/Element/Blank.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Blank;
+# ABSTRACT: blank element
 
 
 use Moose;
@@ -38,10 +39,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Blank - blank element
 
 =head1 SEE ALSO
 

--- a/lib/HTML/FormFu/Element/Block.pm
+++ b/lib/HTML/FormFu/Element/Block.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Block;
+# ABSTRACT: Block element
 
 
 use Moose;
@@ -261,10 +262,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Block - Block element
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Button.pm
+++ b/lib/HTML/FormFu/Element/Button.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Button;
+# ABSTRACT: Button form field
 
 
 use Moose;
@@ -22,10 +23,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Button - Button form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Checkbox.pm
+++ b/lib/HTML/FormFu/Element/Checkbox.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Checkbox;
+# ABSTRACT: Checkbox form field
 
 
 use Moose;
@@ -81,10 +82,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Checkbox - Checkbox form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Checkboxgroup.pm
+++ b/lib/HTML/FormFu/Element/Checkboxgroup.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Checkboxgroup;
+# ABSTRACT: Group of checkbox form fields
 
 
 use Moose;
@@ -237,10 +238,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Checkboxgroup - Group of checkbox form fields
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/ComboBox.pm
+++ b/lib/HTML/FormFu/Element/ComboBox.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::ComboBox;
+# ABSTRACT: Select / Text hybrid
 
 
 use Moose;
@@ -290,10 +291,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::ComboBox - Select / Text hybrid
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/ContentButton.pm
+++ b/lib/HTML/FormFu/Element/ContentButton.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::ContentButton;
+# ABSTRACT: Button form field containing markup
 
 
 use Moose;
@@ -66,10 +67,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::ContentButton - Button form field containing markup
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Date.pm
+++ b/lib/HTML/FormFu/Element/Date.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Date;
+# ABSTRACT: 3 select menu multi-field
 
 
 use Moose;
@@ -491,10 +492,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Date - 3 select menu multi-field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/DateTime.pm
+++ b/lib/HTML/FormFu/Element/DateTime.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::DateTime;
+# ABSTRACT: Date / Time combo field
 
 
 use Moose;
@@ -175,10 +176,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::DateTime - Date / Time combo field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Email.pm
+++ b/lib/HTML/FormFu/Element/Email.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Email;
+# ABSTRACT: HTML5 email form field
 
 
 use Moose;
@@ -23,10 +24,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Email - HTML5 email form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Fieldset.pm
+++ b/lib/HTML/FormFu/Element/Fieldset.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Fieldset;
+# ABSTRACT: Fieldset element
 
 
 use Moose;
@@ -36,10 +37,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Fieldset - Fieldset element
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/File.pm
+++ b/lib/HTML/FormFu/Element/File.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::File;
+# ABSTRACT: File upload form field
 
 
 use Moose;
@@ -23,10 +24,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::File - File upload form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Hidden.pm
+++ b/lib/HTML/FormFu/Element/Hidden.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Hidden;
+# ABSTRACT: Hidden form field
 
 
 use Moose;
@@ -26,10 +27,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Hidden - Hidden form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Hr.pm
+++ b/lib/HTML/FormFu/Element/Hr.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Hr;
+# ABSTRACT: horizontal-rule element
 
 
 use Moose;
@@ -21,10 +22,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Hr - horizontal-rule element
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Element/Image.pm
+++ b/lib/HTML/FormFu/Element/Image.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Image;
+# ABSTRACT: Image button form field
 
 
 use Moose;
@@ -25,10 +26,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Image - Image button form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Label.pm
+++ b/lib/HTML/FormFu/Element/Label.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Label;
+# ABSTRACT: field for displaying only
 
 
 use Moose;
@@ -90,10 +91,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Label - field for displaying only
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Element/Multi.pm
+++ b/lib/HTML/FormFu/Element/Multi.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Multi;
+# ABSTRACT: Combine multiple fields in a single element
 
 
 use Moose;
@@ -191,10 +192,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Multi - Combine multiple fields in a single element
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Number.pm
+++ b/lib/HTML/FormFu/Element/Number.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Number;
+# ABSTRACT: Number element with formatting
 
 
 use Moose;
@@ -33,10 +34,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Number - Number element with formatting
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Password.pm
+++ b/lib/HTML/FormFu/Element/Password.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Password;
+# ABSTRACT: Password form field
 
 
 use Moose;
@@ -54,10 +55,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Password - Password form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Radio.pm
+++ b/lib/HTML/FormFu/Element/Radio.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Radio;
+# ABSTRACT: Radio form field
 
 
 use Moose;
@@ -23,10 +24,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Radio - Radio form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Radiogroup.pm
+++ b/lib/HTML/FormFu/Element/Radiogroup.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Radiogroup;
+# ABSTRACT: Group of radiobutton form fields
 
 
 use Moose;
@@ -22,10 +23,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Radiogroup - Group of radiobutton form fields
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Repeatable.pm
+++ b/lib/HTML/FormFu/Element/Repeatable.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Repeatable;
+# ABSTRACT: repeatable block element
 
 
 use Moose;
@@ -323,10 +324,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Repeatable - repeatable block element
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Reset.pm
+++ b/lib/HTML/FormFu/Element/Reset.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Reset;
+# ABSTRACT: Reset button form field
 
 
 use Moose;
@@ -19,10 +20,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Reset - Reset button form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Select.pm
+++ b/lib/HTML/FormFu/Element/Select.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Select;
+# ABSTRACT: Select form field
 
 
 use Moose;
@@ -103,10 +104,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Select - Select form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/SimpleTable.pm
+++ b/lib/HTML/FormFu/Element/SimpleTable.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::SimpleTable;
+# ABSTRACT: simple table element
 
 
 use Moose;
@@ -120,10 +121,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::SimpleTable - simple table element
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Src.pm
+++ b/lib/HTML/FormFu/Element/Src.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Src;
+# ABSTRACT: custom HTML element
 
 
 use Moose;
@@ -18,10 +19,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Src - custom HTML element
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Element/Submit.pm
+++ b/lib/HTML/FormFu/Element/Submit.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Submit;
+# ABSTRACT: Submit button form field
 
 
 use Moose;
@@ -19,10 +20,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Submit - Submit button form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Text.pm
+++ b/lib/HTML/FormFu/Element/Text.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Text;
+# ABSTRACT: Text form field
 
 
 use Moose;
@@ -21,10 +22,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Text - Text form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/Textarea.pm
+++ b/lib/HTML/FormFu/Element/Textarea.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::Textarea;
+# ABSTRACT: Textarea form field
 
 
 use Moose;
@@ -53,10 +54,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::Textarea - Textarea form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Element/URL.pm
+++ b/lib/HTML/FormFu/Element/URL.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Element::URL;
+# ABSTRACT: HTML5 URL form field
 
 
 use Moose;
@@ -84,10 +85,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Element::URL - HTML5 URL form field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter.pm
+++ b/lib/HTML/FormFu/Filter.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter;
+# ABSTRACT: Filter Base Class
 
 
 use Moose;
@@ -50,10 +51,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter - Filter Base Class
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/Callback.pm
+++ b/lib/HTML/FormFu/Filter/Callback.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::Callback;
+# ABSTRACT: filter with custom subroutine
 
 
 use Moose;
@@ -24,10 +25,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::Callback - filter with custom subroutine
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/CompoundJoin.pm
+++ b/lib/HTML/FormFu/Filter/CompoundJoin.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::CompoundJoin;
+# ABSTRACT: CompoundJoin filter
 
 
 use Moose;
@@ -36,10 +37,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::CompoundJoin - CompoundJoin filter
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/CompoundSprintf.pm
+++ b/lib/HTML/FormFu/Filter/CompoundSprintf.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::CompoundSprintf;
+# ABSTRACT: CompoundSprintf filter
 
 
 use Moose;
@@ -34,10 +35,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::CompoundSprintf - CompoundSprintf filter
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/CopyValue.pm
+++ b/lib/HTML/FormFu/Filter/CopyValue.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::CopyValue;
+# ABSTRACT: copy the value from another field
 
 
 use Moose;
@@ -33,10 +34,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::CopyValue - copy the value from another field
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/Encode.pm
+++ b/lib/HTML/FormFu/Filter/Encode.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::Encode;
+# ABSTRACT: Encode/Decode Submitted Values
 
 
 use Moose;
@@ -85,10 +86,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::Encode - Encode/Decode Submitted Values
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/ForceListValue.pm
+++ b/lib/HTML/FormFu/Filter/ForceListValue.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::ForceListValue;
+# ABSTRACT: convert a single value into a 1-item-list
 
 
 use Moose;
@@ -17,10 +18,6 @@ sub process {
 };
 
 1;
-
-=head1 NAME
-
-HTML::FormFu::Filter::ForceListValue - convert a single value into a 1-item-list
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/FormatNumber.pm
+++ b/lib/HTML/FormFu/Filter/FormatNumber.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::FormatNumber;
+# ABSTRACT: Convert a formatted number from a known locale
 
 
 use Moose;
@@ -39,10 +40,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::FormatNumber - Convert a formatted number from a known locale
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/HTMLEscape.pm
+++ b/lib/HTML/FormFu/Filter/HTMLEscape.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::HTMLEscape;
+# ABSTRACT: filter escaping HTML
 
 
 use Moose;
@@ -23,10 +24,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::HTMLEscape - filter escaping HTML
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Filter/HTMLScrubber.pm
+++ b/lib/HTML/FormFu/Filter/HTMLScrubber.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::HTMLScrubber;
+# ABSTRACT: filter removing HTML markup
 
 
 use Moose;
@@ -48,10 +49,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::HTMLScrubber - filter removing HTML markup
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Filter/LowerCase.pm
+++ b/lib/HTML/FormFu/Filter/LowerCase.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::LowerCase;
+# ABSTRACT: filter transforming to lower case
 
 
 use Moose;
@@ -18,10 +19,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::LowerCase - filter transforming to lower case
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Filter/NonNumeric.pm
+++ b/lib/HTML/FormFu/Filter/NonNumeric.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::NonNumeric;
+# ABSTRACT: filter removing all non-numeric characters
 
 
 use Moose;
@@ -12,10 +13,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::NonNumeric - filter removing all non-numeric characters
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Filter/Regex.pm
+++ b/lib/HTML/FormFu/Filter/Regex.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::Regex;
+# ABSTRACT: regexp-based match/replace filter
 
 
 use Moose;
@@ -35,10 +36,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::Regex - regexp-based match/replace filter
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/Split.pm
+++ b/lib/HTML/FormFu/Filter/Split.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::Split;
+# ABSTRACT: filter splitting a singe value into an arrayref
 
 
 use Moose;
@@ -31,10 +32,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::Split - filter splitting a singe value into an arrayref
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Filter/TrimEdges.pm
+++ b/lib/HTML/FormFu/Filter/TrimEdges.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::TrimEdges;
+# ABSTRACT: filter trimming whitespace
 
 
 use Moose;
@@ -21,10 +22,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::TrimEdges - filter trimming whitespace
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Filter/UpperCase.pm
+++ b/lib/HTML/FormFu/Filter/UpperCase.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::UpperCase;
+# ABSTRACT: filter transforming to upper case
 
 
 use Moose;
@@ -18,10 +19,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::UpperCase - filter transforming to upper case
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Filter/Whitespace.pm
+++ b/lib/HTML/FormFu/Filter/Whitespace.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Filter::Whitespace;
+# ABSTRACT: filter stripping all whitespace
 
 
 use Moose;
@@ -12,10 +13,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Filter::Whitespace - filter stripping all whitespace
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Inflator.pm
+++ b/lib/HTML/FormFu/Inflator.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Inflator;
+# ABSTRACT: Inflator Base Class
 
 
 use Moose;
@@ -56,10 +57,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Inflator - Inflator Base Class
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Inflator/Callback.pm
+++ b/lib/HTML/FormFu/Inflator/Callback.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Inflator::Callback;
+# ABSTRACT: Callback inflator
 
 
 use Moose;
@@ -24,10 +25,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Inflator::Callback - Callback inflator
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Inflator/CompoundDateTime.pm
+++ b/lib/HTML/FormFu/Inflator/CompoundDateTime.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Inflator::CompoundDateTime;
+# ABSTRACT: CompoundDateTime inflator
 
 
 use Moose;
@@ -76,10 +77,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Inflator::CompoundDateTime - CompoundDateTime inflator
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Inflator/DateTime.pm
+++ b/lib/HTML/FormFu/Inflator/DateTime.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Inflator::DateTime;
+# ABSTRACT: DateTime inflator
 
 
 use Moose;
@@ -89,10 +90,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Inflator::DateTime - DateTime inflator
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Manual/Cookbook.pod
+++ b/lib/HTML/FormFu/Manual/Cookbook.pod
@@ -1,8 +1,5 @@
-#PODNAME: Cookbook.pod
-
-=head1 NAME
-
-HTML::FormFu::Manual::Cookbook - Cooking with HTML::FormFu
+# PODNAME: HTML::FormFu::Manual::Cookbook
+# ABSTRACT: Cooking with HTML::FormFu
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Model.pm
+++ b/lib/HTML/FormFu/Model.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Model;
+# ABSTRACT: base class for models
 
 
 use Moose;
@@ -41,10 +42,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Model - base class for models
 
 =head1 SEE ALSO
 

--- a/lib/HTML/FormFu/Model/HashRef.pm
+++ b/lib/HTML/FormFu/Model/HashRef.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Model::HashRef;
+# ABSTRACT: handle hashrefs
 
 
 use Moose;
@@ -309,10 +310,6 @@ sub get_repeatable {
 __PACKAGE__->meta->make_immutable;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Model::HashRef - handle hashrefs
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/OutputProcessor.pm
+++ b/lib/HTML/FormFu/OutputProcessor.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::OutputProcessor;
+# ABSTRACT: Post-process HTML output
 
 
 use Moose;
@@ -24,10 +25,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::OutputProcessor - Post-process HTML output
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/OutputProcessor/Indent.pm
+++ b/lib/HTML/FormFu/OutputProcessor/Indent.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::OutputProcessor::Indent;
+# ABSTRACT: Nicely Indent HTML Output
 
 
 use Moose;
@@ -100,10 +101,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::OutputProcessor::Indent - Nicely Indent HTML Output
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/OutputProcessor/StripWhitespace.pm
+++ b/lib/HTML/FormFu/OutputProcessor/StripWhitespace.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::OutputProcessor::StripWhitespace;
+# ABSTRACT: Strip shitespace from HTML output
 
 
 use Moose;
@@ -167,10 +168,6 @@ __PACKAGE__->meta->make_immutable( inline_constructor => 0 );
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::OutputProcessor::StripWhitespace - Strip shitespace from HTML output
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Plugin.pm
+++ b/lib/HTML/FormFu/Plugin.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Plugin;
+# ABSTRACT: base class for plugins
 
 
 use Moose;
@@ -34,10 +35,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Plugin - base class for plugins
 
 =head2 DESCRIPTION
 

--- a/lib/HTML/FormFu/Plugin/StashValid.pm
+++ b/lib/HTML/FormFu/Plugin/StashValid.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Plugin::StashValid;
+# ABSTRACT: place valid params on form stash
 
 
 use Moose;
@@ -23,10 +24,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Plugin::StashValid - place valid params on form stash
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Processor.pm
+++ b/lib/HTML/FormFu/Processor.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Processor;
+# ABSTRACT: base class for constraints
 
 
 use Moose;
@@ -65,10 +66,6 @@ sub clone {
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Processor - base class for constraints
 
 =head1 AUTHOR
 

--- a/lib/HTML/FormFu/QueryType/CGI.pm
+++ b/lib/HTML/FormFu/QueryType/CGI.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::QueryType::CGI;
+# ABSTRACT: uploaded file
 
 
 use Moose;
@@ -62,10 +63,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::QueryType::CGI - uploaded file
 
 =head1 METHODS
 

--- a/lib/HTML/FormFu/QueryType/CGI/Simple.pm
+++ b/lib/HTML/FormFu/QueryType/CGI/Simple.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::QueryType::CGI::Simple;
+# ABSTRACT: uploaded file
 
 
 use Moose;
@@ -51,10 +52,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::QueryType::CGI::Simple - uploaded file
 
 =head1 METHODS
 

--- a/lib/HTML/FormFu/QueryType/Catalyst.pm
+++ b/lib/HTML/FormFu/QueryType/Catalyst.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::QueryType::Catalyst;
+# ABSTRACT: uploaded file
 
 
 use Moose;
@@ -71,10 +72,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::QueryType::Catalyst - uploaded file
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Role/Constraint/Others.pm
+++ b/lib/HTML/FormFu/Role/Constraint/Others.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Role::Constraint::Others;
+# ABSTRACT: Base class for constraints needing others() method
 
 
 use Moose::Role;
@@ -208,10 +209,6 @@ around clone => sub {
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Role::Constraint::Others - Base class for constraints needing others() method
 
 =head1 METHODS
 

--- a/lib/HTML/FormFu/Role/Element/Field.pm
+++ b/lib/HTML/FormFu/Role/Element/Field.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Role::Element::Field;
+# ABSTRACT: Role for all form-field elements
 
 
 use Moose::Role;
@@ -1148,10 +1149,6 @@ around clone => sub {
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Role::Element::Field - Role for all form-field elements
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Role/Element/Group.pm
+++ b/lib/HTML/FormFu/Role/Element/Group.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Role::Element::Group;
+# ABSTRACT: Role for grouped form fields
 
 
 use Moose::Role;
@@ -386,10 +387,6 @@ around clone => sub {
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Role::Element::Group - Role for grouped form fields
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Role/Element/Input.pm
+++ b/lib/HTML/FormFu/Role/Element/Input.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Role::Element::Input;
+# ABSTRACT: Role for input fields
 
 
 use Moose::Role;
@@ -273,10 +274,6 @@ around clone => sub {
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Role::Element::Input - Role for input fields
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Role/Element/NonBlock.pm
+++ b/lib/HTML/FormFu/Role/Element/NonBlock.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Role::Element::NonBlock;
+# ABSTRACT: base class for single-tag elements
 
 
 use Moose::Role;
@@ -50,10 +51,6 @@ sub string {
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Role::Element::NonBlock - base class for single-tag elements
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Role/Filter/Compound.pm
+++ b/lib/HTML/FormFu/Role/Filter/Compound.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Role::Filter::Compound;
+# ABSTRACT: Role for Compound filters
 
 
 use Moose::Role;
@@ -35,10 +36,6 @@ sub _get_values {
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Role::Filter::Compound - Role for Compound filters
 
 =head1 METHODS
 

--- a/lib/HTML/FormFu/Transformer.pm
+++ b/lib/HTML/FormFu/Transformer.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Transformer;
+# ABSTRACT: Transformer Base Class
 
 
 use Moose;
@@ -57,10 +58,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Transformer - Transformer Base Class
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Transformer/Callback.pm
+++ b/lib/HTML/FormFu/Transformer/Callback.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Transformer::Callback;
+# ABSTRACT: Callback transformer
 
 
 use Moose;
@@ -26,10 +27,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Transformer::Callback - Callback transformer
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Upload.pm
+++ b/lib/HTML/FormFu/Upload.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Upload;
+# ABSTRACT: uploaded file
 
 
 use Moose;
@@ -50,10 +51,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Upload - uploaded file
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/UploadParam.pm
+++ b/lib/HTML/FormFu/UploadParam.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::UploadParam;
+# ABSTRACT: accessor class
 
 
 use Moose;
@@ -89,10 +90,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::UploadParam - accessor class
 
 =head1 DESCRIPTION
 

--- a/lib/HTML/FormFu/Validator.pm
+++ b/lib/HTML/FormFu/Validator.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Validator;
+# ABSTRACT: Validator Base Class
 
 
 use Moose;
@@ -67,10 +68,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Validator - Validator Base Class
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/FormFu/Validator/Callback.pm
+++ b/lib/HTML/FormFu/Validator/Callback.pm
@@ -1,5 +1,6 @@
 use strict;
 package HTML::FormFu::Validator::Callback;
+# ABSTRACT: Callback validator
 
 
 use Moose;
@@ -26,10 +27,6 @@ __PACKAGE__->meta->make_immutable;
 1;
 
 __END__
-
-=head1 NAME
-
-HTML::FormFu::Validator::Callback - Callback validator
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
replaces manual `=head1 NAME` sections with `# ABSTRACT` headers for Pod::Weaver to weave.

Does not add `# ABSTRACT` to the files that didn't have an name section with abstract.  Those files still produce warning messages during dzil build.