### PR TITLE
Fix default name for label template from 'lable' to 'field_layout_label'

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+2.08      2021-01-15 10:16:00+00:00 UTC
+
+    - Fix label template default name in label_filename method 
+
 2.07      2018-12-14 15:55:00+00:00 UTC
 
     - Fix handling or error_attributes & error_container_attributes

--- a/lib/HTML/FormFu/Role/Element/Field.pm
+++ b/lib/HTML/FormFu/Role/Element/Field.pm
@@ -80,7 +80,7 @@ after BUILD => sub {
     $self->label_attributes(           {} );
     $self->error_attributes(           {} );
     $self->error_container_attributes( {} );
-    $self->label_filename('label');
+    $self->label_filename('field_layout_label');
     $self->label_tag('label');
     $self->container_tag('div');
     $self->is_field(1);
@@ -1795,7 +1795,7 @@ Must be set by more specific field classes.
 
 The template filename to be used to render the label.
 
-Defaults to C<label>.
+Defaults to C<field_layout_label>.
 
 =head1 ERROR HANDLING
 


### PR DESCRIPTION
You leave default label_filename as old template name (label) from 1 version. I fix default name for label template from 'lable' to 'field_layout_label'